### PR TITLE
Reproduce env var build error

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -12,10 +12,6 @@
       "outputs": [
         ".svelte-kit/**",
         ".vercel/**"
-      ],
-      "env": [
-        "PUBLIC_*",
-        "PRIVATE_*"
       ]
     },
     "lint": {},


### PR DESCRIPTION
This PR demonstrates how Turbo framework inference defaults do not work for SvelteKit by removing them from `turbo.json`.